### PR TITLE
feat: add meilisearch-job container configuration

### DIFF
--- a/tutor_meili/patches/k8s-jobs
+++ b/tutor_meili/patches/k8s-jobs
@@ -1,0 +1,22 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: meilisearch-job
+  labels:
+    app.kubernetes.io/component: job
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: meilisearch
+          image: {{ MEILISEARCH_DOCKER_IMAGE }}
+
+          env:
+            - name: MEILI_MASTER_KEY
+              value: "{{ MEILISEARCH_MASTER_KEY }}"
+            - name: MEILISEARCH__INTERNAL_API_KEY_UID 
+              value: "{{ MEILISEARCH__INTERNAL_API_KEY_UID }}"
+            - name: MEILISEARCH_INDEX_PREFIX
+              value: "{{ MEILISEARCH_INDEX_PREFIX }}"


### PR DESCRIPTION
This PR adds the meilisearch-job container to run the meilisearch initialization script that sets the master API key.

This fixes the following error:
![image](https://github.com/open-craft/tutor-contrib-meilisearch/assets/849463/7f0a4315-d147-4299-a890-9d45aa7d37e2)
