### PR TITLE
Automatically build the Studio index when initializing Meilisearch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Configuration
 
 - ``MEILISEARCH_INDEX_PREFIX`` (default: ``"tutor_"``)
 - ``MEILISEARCH_PUBLIC_HOST`` (default: ``"meilisearch.{{ LMS_HOST }}"``)
-- ``MEILISEARCH_DOCKER_IMAGE`` (default: ``"docker.io/getmeili/meilisearch:v1.7``)
+- ``MEILISEARCH_DOCKER_IMAGE`` (default: ``"docker.io/getmeili/meilisearch:v1.8``)
 - ``MEILISEARCH_MASTER_KEY`` The master key. Only required to generate the API key (default: auto-generated).
 - ``MEILISEARCH_API_KEY`` The API key (or tenant key) to use for this Open edX instance (default: auto-generated using the master key).
 
@@ -45,7 +45,6 @@ smaller installations, the easier way is to follow this procedure::
     tutor config save
     tutor [local|dev] start -d meilisearch
     tutor [local|dev] do init --limit=meilisearch
-    tutor dev run cms ./manage.py cms reindex_studio --experimental
 
 TODO
 ----


### PR DESCRIPTION
With this change, you no longer have to run `./manage.py cms reindex_studio --experimental` when setting up a new instance of Open edX using this plugin. It will run automatically during the tutor init phase.