### PR TITLE
fix: avoid full reindex_studio on deployment

### DIFF
--- a/tutor_meili/plugin.py
+++ b/tutor_meili/plugin.py
@@ -79,9 +79,10 @@ tutor_hooks.Filters.CLI_DO_INIT_TASKS.add_item(
     ("meilisearch", (SCRIPTS / "init.sh").read_text()),
     priority=tutor_hooks.priorities.HIGH,
 )
-# This script will (re-)index all the Studio content:
+# This script will create the Studio content index, and print
+# instructions on how to reindex studio content, if needed.
 tutor_hooks.Filters.CLI_DO_INIT_TASKS.add_item(
-    ("cms", "./manage.py cms reindex_studio --experimental"),
+    ("cms", "./manage.py cms reindex_studio --experimental --init"),
     priority=tutor_hooks.priorities.LOW,
 )
 


### PR DESCRIPTION
and just use `--init` instead.

Ensures this plugin's initialization uses [the same arguments as in tutor core](https://github.com/overhangio/tutor/blob/3bffdd5ab80d85c238c8f33cf83eee3e1a713863/tutor/templates/jobs/init/cms.sh#L20C55-L24).

See https://github.com/openedx/frontend-app-authoring/issues/1456#issuecomment-2582751982.

Private-ref: [FAL-4017](https://tasks.opencraft.com/browse/FAL-4017)

### Testing instructions

1. Check the code change against its equivalent in [tutor core](https://github.com/overhangio/tutor/blob/3bffdd5ab80d85c238c8f33cf83eee3e1a713863/tutor/templates/jobs/init/cms.sh#L20C55-L24).
2. Ensure the arguments passed to `reindex_studio` are correct and valid.